### PR TITLE
refactor: enhance arxiv logic modularity and implement robust testing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::arxiv::ArxivQueryResult;
 use crate::config::{Config, HighlightConfig};
-use crate::ui::{ArticleDetails, ArticleFeed, ConfigPopup, Theme};
+use crate::ui::{option_vec_to_option_slice, ArticleDetails, ArticleFeed, ConfigPopup, Theme};
 use arboard::Clipboard;
 use std::error::Error;
 
@@ -32,12 +32,6 @@ pub struct App<'a> {
     pub config: Config,
 }
 
-fn option_vec_to_option_slice(option_vec: &Option<Vec<String>>) -> Option<Vec<&str>> {
-    let binding = option_vec
-        .as_deref()
-        .map(|v| v.iter().map(String::as_str).collect::<Vec<&str>>());
-    binding
-}
 
 impl<'a> App<'a> {
     pub fn new(

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,6 @@ pub struct App<'a> {
     pub config: Config,
 }
 
-
 impl<'a> App<'a> {
     pub fn new(
         query_result: &'a ArxivQueryResult,

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,8 @@ fn main() -> AppResult<()> {
         Some(DEFAULT_SORT_BY),
         Some(DEFAULT_SORT_ORDER),
     );
-    let query_result = ArxivQueryResult::from_query(query)
-        .map_err(|e| format!("Failed to query arXiv: {e}"))?;
+    let query_result =
+        ArxivQueryResult::from_query(query).map_err(|e| format!("Failed to query arXiv: {e}"))?;
 
     // Create a longer-lived value for the highlight config
     let highlight_config = config.highlight.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ fn main() -> AppResult<()> {
         Some(DEFAULT_SORT_BY),
         Some(DEFAULT_SORT_ORDER),
     );
-    let query_result = ArxivQueryResult::from_query(query);
+    let query_result = ArxivQueryResult::from_query(query)
+        .map_err(|e| format!("Failed to query arXiv: {e}"))?;
 
     // Create a longer-lived value for the highlight config
     let highlight_config = config.highlight.clone();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,9 +8,8 @@ pub use detail::ArticleDetails;
 pub use list::ArticleFeed;
 pub use style::Theme;
 
-fn option_vec_to_option_slice(option_vec: &Option<Vec<String>>) -> Option<Vec<&str>> {
-    let binding = option_vec
+pub fn option_vec_to_option_slice(option_vec: &Option<Vec<String>>) -> Option<Vec<&str>> {
+    option_vec
         .as_deref()
-        .map(|v| v.iter().map(String::as_str).collect::<Vec<&str>>());
-    binding
+        .map(|v| v.iter().map(String::as_str).collect::<Vec<&str>>())
 }

--- a/tests/fixtures/authors_sample.xml
+++ b/tests/fixtures/authors_sample.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <author>
+    <name>Author Name 1</name>
+   </author>
+   <author>
+    <name>Author Name 2, Second</name>
+  </author>
+</feed>

--- a/tests/fixtures/empty_authors.xml
+++ b/tests/fixtures/empty_authors.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+</feed>

--- a/tests/fixtures/sample_arxiv.xml
+++ b/tests/fixtures/sample_arxiv.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <link href="http://arxiv.org/api/query?search_query=fake%3Atopic&amp;id_list=&amp;start=0&amp;max_results=20" rel="self" type="application/atom+xml"/>
+  <title type="html">ArXiv Query: search_query=fake:topic&amp;id_list=&amp;start=0&amp;max_results=20</title>
+  <id>http://arxiv.org/api/FAKESAMPLEID</id>
+  <updated>2024-07-09T20:00:00Z</updated>
+  <opensearch:totalResults xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">10</opensearch:totalResults>
+  <opensearch:startIndex xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">0</opensearch:startIndex>
+  <opensearch:itemsPerPage xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">20</opensearch:itemsPerPage>
+  <entry>
+    <id>http://arxiv.org/abs/9876.54321</id>
+    <updated>2023-12-31T23:59:59Z</updated>
+    <published>2023-12-31T23:59:59Z</published>
+    <title>Sample Title 1</title>
+    <summary>This is a summary for the first fake entry used for testing purposes.</summary>
+    <author>
+      <name>Author One</name>
+    </author>
+    <author>
+      <name>Author Two</name>
+    </author>
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/1212.34567</id>
+    <updated>2024-01-01T00:00:00Z</updated>
+    <published>2024-01-01T00:00:00Z</published>
+    <title>Sample Title 2</title>
+    <summary>This is a sample summary for the second entry.</summary>
+    <author>
+      <name>Author Three</name>
+    </author>
+  </entry>
+</feed>


### PR DESCRIPTION
- Integrated 'serde' to provide Serialize and Deserialize derivations for Paper, Author, and Query structs.
- Replaced 'Box<dyn Error>' with domain-specific 'ArxivParsingError' and 'ArxivQueryError' using 'thiserror'.
- Refactored 'ArxivQueryResult' to return Result types, removing previous 'unwrap' and 'panic' calls.
- Relocated 'option_vec_to_option_slice' utility from 'App' to 'ui' module and updated visibility to public.
- Migrated inline XML test strings to dedicated external files in 'tests/fixtures/'
- Refactored 'load_fixture' to use CARGO_MANIFEST_DIR for location-agnostic pathing.
- Added defensive 'test_truncated_xml' to verify parser resilience against malformed inputs.
- Standardized all unit tests to support new Result-based return signatures.