### PR TITLE
refactor: decouple arXiv API from TUI rendering logic

### DIFF
--- a/src/arxiv/parsing.rs
+++ b/src/arxiv/parsing.rs
@@ -7,8 +7,6 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::search_highlight::search_patterns;
-
 const ENTRY_NS: &str = "http://www.w3.org/2005/Atom";
 
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
@@ -45,15 +43,6 @@ impl ArxivEntry {
 
     pub fn get_all_authors(&self) -> &str {
         &self.all_authors
-    }
-
-    pub fn contains_author(&self, author_patterns: Option<&[&str]>) -> bool {
-        if let Some(patterns) = author_patterns {
-            let matches = search_patterns(&self.all_authors, patterns);
-            !matches.is_empty()
-        } else {
-            false
-        }
     }
 }
 
@@ -223,36 +212,6 @@ mod tests {
 
         let result = Element::from_str(malformed_xml);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_arxiv_entry_contains_author() {
-        let entry = ArxivEntry::new(
-            "Test Title".to_string(),
-            vec!["John Doe".to_string(), "Jane Smith".to_string()],
-            "Test Summary".to_string(),
-            "test_id".to_string(),
-            "2024-03-28".to_string(),
-            "2024-03-28".to_string(),
-        );
-
-        // Test exact match
-        assert!(entry.contains_author(Some(&["John Doe"])));
-
-        // Test partial match
-        assert!(entry.contains_author(Some(&["Doe"])));
-
-        // Test case sensitivity
-        assert!(entry.contains_author(Some(&["john doe"])));
-
-        // Test no match
-        assert!(!entry.contains_author(Some(&["Albert Einstein"])));
-
-        // Test empty patterns
-        assert!(!entry.contains_author(Some(&[])));
-
-        // Test None patterns
-        assert!(!entry.contains_author(None));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@ pub mod tui;
 /// Event handler.
 pub mod handler;
 
-/// Searching keyword
-pub mod search_highlight;
-
 /// Handling config
 pub mod config;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,6 +2,7 @@ pub mod config_popup;
 pub mod detail;
 pub mod list;
 pub mod style;
+pub mod utils;
 
 pub use config_popup::ConfigPopup;
 pub use detail::ArticleDetails;

--- a/src/ui/detail.rs
+++ b/src/ui/detail.rs
@@ -1,6 +1,6 @@
+use super::utils::highlight_patterns;
 use crate::arxiv::ArxivEntry;
 use crate::config::HighlightConfig;
-use crate::search_highlight::highlight_patterns;
 use crate::ui::Theme;
 
 use super::option_vec_to_option_slice;

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -1,4 +1,5 @@
 use crate::arxiv::ArxivQueryResult;
+use crate::ui::utils::check_author_match;
 use crate::ui::Theme;
 use ratatui::widgets::{List, ListState};
 use ratatui::{
@@ -24,7 +25,9 @@ impl ArticleFeed<'_> {
             .iter()
             .map(|entry| {
                 ListItem::from(entry.title.clone()).style(
-                    if entry.contains_author(highlight_authors) {
+                    if highlight_authors.map_or(false, |patterns| {
+                        check_author_match(&entry.authors, patterns)
+                    }) {
                         theme.title
                     } else {
                         theme.main

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -25,9 +25,9 @@ impl ArticleFeed<'_> {
             .iter()
             .map(|entry| {
                 ListItem::from(entry.title.clone()).style(
-                    if highlight_authors.is_some_and(|patterns| {
-                        check_author_match(&entry.authors, patterns)
-                    }) {
+                    if highlight_authors
+                        .is_some_and(|patterns| check_author_match(&entry.authors, patterns))
+                    {
                         theme.title
                     } else {
                         theme.main

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -25,7 +25,7 @@ impl ArticleFeed<'_> {
             .iter()
             .map(|entry| {
                 ListItem::from(entry.title.clone()).style(
-                    if highlight_authors.map_or(false, |patterns| {
+                    if highlight_authors.is_some_and(|patterns| {
                         check_author_match(&entry.authors, patterns)
                     }) {
                         theme.title

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,9 +1,19 @@
-//! Module for highligting keyword in a text.
+//! Module for highlighting keyword in a text.
 
 use aho_corasick::AhoCorasick;
 use ratatui::text::{Line, Span};
 
 use crate::ui::Theme;
+
+pub fn check_author_match(authors: &[String], patterns: &[&str]) -> bool {
+    if patterns.is_empty() {
+        return false;
+    }
+
+    let author_text = authors.join(", ");
+    let matches = search_patterns(&author_text, patterns);
+    !matches.is_empty()
+}
 
 pub fn search_patterns(text: &str, patterns: &[&str]) -> Vec<(usize, usize)> {
     let ac = AhoCorasick::builder()


### PR DESCRIPTION
- Move search_highlight logic to src/ui/utils.rs
- Remove TUI-specific methods (contains_author) from ArxivEntry
- Update UI components to use standalone utility functions for highlighting
- Register utils module in src/ui.rs and remove search_highlight from lib.rs

This separation ensures the arxiv module only handles data retrieval, preparing the codebase for future local database integration.

closes(#19)