### PR TITLE
refactor: consolidate arXiv query logic and stabilize API connection

### DIFF
--- a/src/arxiv/parsing.rs
+++ b/src/arxiv/parsing.rs
@@ -151,11 +151,6 @@ impl ArxivQueryResult {
             articles,
         })
     }
-    pub fn from_query(query: String) -> Result<Self, ArxivParsingError> {
-        let query_response = reqwest::blocking::get(query)?;
-        let xml_content = query_response.text()?;
-        Self::from_xml_content(&xml_content)
-    }
 }
 
 #[cfg(test)]

--- a/src/arxiv/query.rs
+++ b/src/arxiv/query.rs
@@ -23,7 +23,7 @@ use std::collections::BTreeMap;
 use std::fmt::Display;
 use thiserror::Error;
 
-const ARXIV_QUERY_BASE_URL: &str = "http://export.arxiv.org/api/query?";
+const ARXIV_QUERY_BASE_URL: &str = "https://export.arxiv.org/api/query?";
 
 // --- Construct the search query ---
 
@@ -267,7 +267,22 @@ pub fn query_arxiv(
         sort_by,
         sort_order,
     );
-    Ok(reqwest::blocking::get(query_str)?.text()?)
+    let ua = format!(
+        "arxivlens/{} (+https://github.com/AlMrvn/arxivlens)",
+        env!("CARGO_PKG_VERSION")
+    );
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(ua)
+        .build()
+        .map_err(ArxivQueryError::NetworkError)?;
+    let response = client
+        .get(query_str)
+        .send()
+        .map_err(ArxivQueryError::NetworkError)?;
+
+    let text = response.text()?;
+
+    Ok(text)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Move all network fetching into `query_arxiv` to ensure a single source of truth.
- Delete redundant `ArxivQueryResult::from_query` to prevent logic drift.
- Update base URL to HTTPS and implement a custom User-Agent to prevent arXiv firewall blocks.
- Improve error handling in `resolve_query` for clearer TUI feedback.